### PR TITLE
fix(shanten): correct calculation logic to use 13 tiles and add validation

### DIFF
--- a/app/lib/hai/shanten.test.ts
+++ b/app/lib/hai/shanten.test.ts
@@ -1,0 +1,718 @@
+import { describe, expect, it } from "vitest";
+import { calculateShanten } from "./shanten";
+import { constructHai, type Hai } from "./types";
+
+// Helper to create suhai tiles
+function manzu(value: number): Hai {
+	return constructHai("manzu", value);
+}
+
+function pinzu(value: number): Hai {
+	return constructHai("pinzu", value);
+}
+
+function souzu(value: number): Hai {
+	return constructHai("souzu", value);
+}
+
+function jihai(value: string): Hai {
+	return constructHai("jihai", value);
+}
+
+describe("calculateShanten", () => {
+	describe("14 tiles - Agari (winning hand)", () => {
+		it("should recognize standard form win", () => {
+			// Complete hand: 4 mentsu + 1 janto (14 tiles)
+			const tehai: Hai[] = [
+				// Janto (pair)
+				manzu(1),
+				manzu(1),
+				// Koutsu (triplet)
+				manzu(9),
+				manzu(9),
+				manzu(9),
+				// Syuntsu (sequence)
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				// Syuntsu
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				// Koutsu
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"),
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isAgari).toBe(true);
+			expect(result.shanten).toBe(-1);
+		});
+
+		it("should recognize chiitoitsu win (7 pairs)", () => {
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1),
+				manzu(3),
+				manzu(3),
+				pinzu(2),
+				pinzu(2),
+				pinzu(5),
+				pinzu(5),
+				souzu(1),
+				souzu(1),
+				souzu(7),
+				souzu(7),
+				jihai("ton"),
+				jihai("ton"),
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isAgari).toBe(true);
+			expect(result.shanten).toBe(-1);
+		});
+
+		it("should recognize mixed hand win", () => {
+			// Another standard form win
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(2),
+				manzu(3),
+				manzu(4),
+				manzu(5),
+				manzu(6),
+				pinzu(7),
+				pinzu(8),
+				pinzu(9),
+				pinzu(7),
+				pinzu(8),
+				pinzu(9),
+				souzu(1),
+				souzu(1),
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isAgari).toBe(true);
+			expect(result.shanten).toBe(-1);
+		});
+	});
+
+	describe("13 tiles - Tenpai (ready hand)", () => {
+		it("should recognize tenpai in standard form", () => {
+			// Waiting on one tile for complete hand
+			const tehai: Hai[] = [
+				// Janto
+				manzu(1),
+				manzu(1),
+				// Two syuntsu
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				// One koutsu
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"),
+				// Partial syuntsu (waiting for pinzu(2))
+				pinzu(2),
+				pinzu(3),
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isTenpai).toBe(true);
+			expect(result.shanten).toBe(0);
+			expect(result.isAgari).toBe(false);
+		});
+
+		it("should recognize tenpai waiting on multiple tiles", () => {
+			// Classic tenpai: 1-4-7 wait
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1), // janto
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				pinzu(4),
+				pinzu(5),
+				pinzu(6),
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				jihai("ton"),
+				jihai("ton"),
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isTenpai).toBe(true);
+			expect(result.shanten).toBe(0);
+		});
+
+		it("should recognize chiitoitsu tenpai (6 pairs)", () => {
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1),
+				manzu(3),
+				manzu(3),
+				pinzu(2),
+				pinzu(2),
+				pinzu(5),
+				pinzu(5),
+				souzu(1),
+				souzu(1),
+				souzu(7),
+				souzu(7),
+				jihai("ton"), // Single tile waiting
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isTenpai).toBe(true);
+			expect(result.shanten).toBe(0);
+		});
+	});
+
+	describe("13 tiles - 1-shanten", () => {
+		it("should calculate 1-shanten for standard form", () => {
+			// Need 2 more tiles to complete
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1), // janto
+				pinzu(1),
+				pinzu(2),
+				pinzu(3), // completed syuntsu
+				souzu(1),
+				souzu(2), // partial syuntsu
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"), // completed koutsu
+				manzu(5),
+				manzu(6), // partial syuntsu
+				manzu(9), // isolated
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.shanten).toBe(1);
+			expect(result.isTenpai).toBe(false);
+		});
+
+		it("should calculate 1-shanten for chiitoitsu (5 pairs)", () => {
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1),
+				manzu(3),
+				manzu(3),
+				pinzu(2),
+				pinzu(2),
+				pinzu(5),
+				pinzu(5),
+				souzu(1),
+				souzu(1),
+				jihai("ton"),
+				jihai("nan"),
+				jihai("sya"),
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.shanten).toBe(1);
+		});
+	});
+
+	describe("13 tiles - Higher shanten numbers", () => {
+		it("should calculate 2-shanten", () => {
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(3),
+				manzu(5),
+				manzu(7),
+				manzu(9),
+				pinzu(1),
+				pinzu(3),
+				pinzu(5),
+				pinzu(7),
+				pinzu(9),
+				souzu(1),
+				souzu(5),
+				jihai("ton"),
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.shanten).toBeGreaterThanOrEqual(2);
+		});
+
+		it("should calculate shanten for all isolated tiles", () => {
+			// 13 completely different tiles (no pairs)
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(2),
+				manzu(4),
+				manzu(6),
+				manzu(8),
+				pinzu(1),
+				pinzu(3),
+				pinzu(5),
+				pinzu(7),
+				pinzu(9),
+				souzu(2),
+				souzu(4),
+				jihai("ton"),
+			];
+
+			const result = calculateShanten(tehai);
+			// This is 4-shanten (has some partial sequences)
+			expect(result.shanten).toBeGreaterThanOrEqual(3);
+		});
+	});
+
+	describe("14 tiles - Shanten calculation", () => {
+		it("should calculate shanten for non-winning 14 tile hand", () => {
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1),
+				manzu(2),
+				manzu(3),
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				pinzu(4),
+				pinzu(5),
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				jihai("ton"),
+				jihai("nan"),
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isAgari).toBe(false);
+			expect(result.shanten).toBeGreaterThanOrEqual(0);
+		});
+
+		it("should return shanten 0 for 14 tiles one discard from tenpai", () => {
+			// 14 tiles that form a complete hand (agari)
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1), // janto
+				pinzu(1),
+				pinzu(2),
+				pinzu(3), // syuntsu
+				souzu(1),
+				souzu(2),
+				souzu(3), // syuntsu
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"), // koutsu
+				manzu(5),
+				manzu(6),
+				manzu(7), // extra syuntsu
+			];
+
+			const result = calculateShanten(tehai);
+			// This is actually a winning hand (4 mentsu + 1 janto)
+			expect(result.isAgari).toBe(true);
+			expect(result.shanten).toBe(-1);
+		});
+
+		it("should calculate shanten for 14 tiles that are not agari", () => {
+			// 14 tiles that are NOT a winning hand
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1), // janto
+				pinzu(1),
+				pinzu(2),
+				pinzu(3), // syuntsu
+				souzu(1),
+				souzu(2),
+				souzu(3), // syuntsu
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"), // koutsu
+				manzu(5),
+				manzu(6),
+				manzu(8), // incomplete - missing manzu(7)
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isAgari).toBe(false);
+			// This should be tenpai (waiting on manzu(7))
+			expect(result.shanten).toBe(0);
+		});
+
+		it("should calculate shanten based on 13 tiles even when given 14", () => {
+			// 14 tiles - should try all possible discards and find best 13-tile shanten
+			const tehai14: Hai[] = [
+				manzu(1),
+				manzu(2),
+				manzu(3), // syuntsu
+				pinzu(1),
+				pinzu(2),
+				pinzu(3), // syuntsu
+				souzu(1),
+				souzu(2),
+				souzu(3), // syuntsu
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"), // koutsu
+				manzu(5), // extra tile
+				manzu(7), // extra tile (not connected)
+			];
+
+			const result14 = calculateShanten(tehai14);
+
+			// Compare with 13-tile versions (removing each extra tile)
+			const tehai13A = tehai14.filter((_, i) => i !== 12); // Remove manzu(5)
+			const tehai13B = tehai14.filter((_, i) => i !== 13); // Remove manzu(7)
+
+			const result13A = calculateShanten(tehai13A);
+			const result13B = calculateShanten(tehai13B);
+
+			// 14-tile result should be the minimum of all 13-tile possibilities
+			const expectedMin = Math.min(result13A.shanten, result13B.shanten);
+			expect(result14.shanten).toBe(expectedMin);
+		});
+	});
+
+	describe("13 vs 14 tile distinction", () => {
+		it("should handle 13 tile hand correctly (normal playing state)", () => {
+			// Standard 13 tile hand, tenpai
+			const tehai13: Hai[] = [
+				manzu(1),
+				manzu(1),
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"),
+				manzu(5),
+				manzu(6), // waiting on manzu(4) or manzu(7)
+			];
+
+			const result = calculateShanten(tehai13);
+			expect(result.isAgari).toBe(false); // Can't win with 13 tiles
+			expect(result.isTenpai).toBe(true);
+			expect(result.shanten).toBe(0);
+		});
+
+		it("should handle 14 tile hand for agari check (after drawing)", () => {
+			// Same hand but with drawn tile (14 tiles) - should be agari
+			const tehai14: Hai[] = [
+				manzu(1),
+				manzu(1),
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"),
+				manzu(5),
+				manzu(6),
+				manzu(7), // completed the syuntsu
+			];
+
+			const result = calculateShanten(tehai14);
+			expect(result.isAgari).toBe(true); // Should recognize win
+			expect(result.shanten).toBe(-1);
+		});
+
+		it("should distinguish between 13 tile tenpai and 14 tile agari", () => {
+			// 13 tiles waiting
+			const tehai13: Hai[] = [
+				manzu(1),
+				manzu(1),
+				manzu(2),
+				manzu(3),
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"),
+			];
+
+			const result13 = calculateShanten(tehai13);
+			expect(result13.isAgari).toBe(false);
+			expect(result13.isTenpai).toBe(true);
+			expect(result13.shanten).toBe(0);
+
+			// Same hand + winning tile (14 tiles)
+			const tehai14: Hai[] = [...tehai13, manzu(4)];
+
+			const result14 = calculateShanten(tehai14);
+			expect(result14.isAgari).toBe(true);
+			expect(result14.shanten).toBe(-1);
+		});
+	});
+
+	describe("Edge cases", () => {
+		it("should handle honor tiles correctly", () => {
+			const tehai: Hai[] = [
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"),
+				jihai("nan"),
+				jihai("nan"),
+				jihai("nan"),
+				jihai("sya"),
+				jihai("sya"),
+				jihai("sya"),
+				jihai("pei"),
+				jihai("pei"),
+				jihai("haku"),
+				jihai("haku"),
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isTenpai).toBe(true);
+			expect(result.shanten).toBe(0);
+		});
+
+		it("should handle four identical tiles correctly", () => {
+			// Hand with 4 of the same tile (kan possibility)
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1),
+				manzu(1),
+				manzu(1), // 4 identical tiles
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"),
+			];
+
+			const result = calculateShanten(tehai);
+			// Should be able to use 3 as koutsu and 1 as part of another combination
+			// or use as koutsu + 1 extra tile
+			expect(result.shanten).toBeGreaterThanOrEqual(-1);
+			expect(result.shanten).toBeLessThanOrEqual(1);
+		});
+
+		it("should handle empty hand gracefully", () => {
+			const tehai: Hai[] = [];
+			const result = calculateShanten(tehai);
+			// Empty hand should have high shanten
+			expect(result.shanten).toBeGreaterThan(0);
+		});
+
+		it("should reject hands with more than 4 of the same tile", () => {
+			// Invalid hand: 5 identical tiles (impossible in real game)
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1),
+				manzu(1),
+				manzu(1),
+				manzu(1), // 5th tile - invalid!
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				jihai("ton"),
+				jihai("ton"),
+			];
+
+			expect(() => calculateShanten(tehai)).toThrow(
+				"Invalid hand: a tile appears more than 4 times",
+			);
+		});
+
+		it("should accept hands with exactly 4 of the same tile", () => {
+			// Valid hand with 4 identical tiles
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1),
+				manzu(1),
+				manzu(1), // 4 identical tiles (valid)
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"),
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.shanten).toBeGreaterThanOrEqual(-1);
+			expect(result.shanten).toBeLessThanOrEqual(8);
+		});
+		it("should handle closed waits correctly", () => {
+			// Penchan wait (edge wait)
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1), // janto
+				manzu(8),
+				manzu(9), // penchan wait for manzu(7)
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"),
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isTenpai).toBe(true);
+			expect(result.shanten).toBe(0);
+		});
+
+		it("should handle kanchan wait (middle wait)", () => {
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1), // janto
+				manzu(4),
+				manzu(6), // kanchan wait for manzu(5)
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"),
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isTenpai).toBe(true);
+			expect(result.shanten).toBe(0);
+		});
+
+		it("should handle shaanpon wait (dual pair wait)", () => {
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1),
+				manzu(2),
+				manzu(2), // shaanpon wait for manzu(1) or manzu(2)
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				jihai("ton"),
+				jihai("ton"),
+				jihai("ton"),
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isTenpai).toBe(true);
+			expect(result.shanten).toBe(0);
+		});
+	});
+
+	describe("Known standard shanten values", () => {
+		it("should return correct shanten for 1-2-3-4-5-6-7-8-9 pattern", () => {
+			// Nine Gates wait pattern (13 tiles)
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1),
+				manzu(2),
+				manzu(3),
+				manzu(4),
+				manzu(5),
+				manzu(6),
+				manzu(7),
+				manzu(8),
+				manzu(9),
+				manzu(9),
+				manzu(9),
+				pinzu(1), // extra tile
+			];
+
+			const result = calculateShanten(tehai);
+			// This is actually 1-shanten since we have extra tile breaking the pattern
+			expect(result.shanten).toBeGreaterThanOrEqual(0);
+		});
+
+		it("should handle repeated sequences correctly", () => {
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(2),
+				manzu(3),
+				manzu(1),
+				manzu(2),
+				manzu(3),
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				souzu(1),
+				souzu(2),
+				souzu(3),
+				manzu(4), // waiting tile
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isTenpai).toBe(true);
+			expect(result.shanten).toBe(0);
+		});
+	});
+
+	describe("Chiitoitsu vs Standard form", () => {
+		it("should choose minimum shanten between forms", () => {
+			// Hand that's better for chiitoitsu
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(1),
+				manzu(5),
+				manzu(5),
+				pinzu(3),
+				pinzu(3),
+				pinzu(7),
+				pinzu(7),
+				souzu(2),
+				souzu(2),
+				jihai("ton"),
+				jihai("ton"),
+				jihai("nan"), // single tile
+			];
+
+			const result = calculateShanten(tehai);
+			// Should be chiitoitsu tenpai (0 shanten)
+			expect(result.shanten).toBe(0);
+		});
+
+		it("should prefer standard form when better", () => {
+			const tehai: Hai[] = [
+				manzu(1),
+				manzu(2),
+				manzu(3),
+				manzu(4),
+				manzu(5),
+				manzu(6),
+				pinzu(1),
+				pinzu(2),
+				pinzu(3),
+				souzu(7),
+				souzu(8),
+				souzu(9),
+				manzu(7), // waiting
+			];
+
+			const result = calculateShanten(tehai);
+			expect(result.isTenpai).toBe(true);
+			expect(result.shanten).toBe(0);
+		});
+	});
+});

--- a/app/lib/hai/shanten.test.ts
+++ b/app/lib/hai/shanten.test.ts
@@ -220,7 +220,7 @@ describe("calculateShanten", () => {
 	});
 
 	describe("13 tiles - Higher shanten numbers", () => {
-		it("should calculate 2-shanten", () => {
+		it("should calculate 4-shanten for scattered tiles", () => {
 			const tehai: Hai[] = [
 				manzu(1),
 				manzu(3),
@@ -238,11 +238,11 @@ describe("calculateShanten", () => {
 			];
 
 			const result = calculateShanten(tehai);
-			expect(result.shanten).toBeGreaterThanOrEqual(2);
+			expect(result.shanten).toBe(4);
 		});
 
-		it("should calculate shanten for all isolated tiles", () => {
-			// 13 completely different tiles (no pairs)
+		it("should calculate 4-shanten for isolated tiles with partial sequences", () => {
+			// 13 tiles with some adjacent tiles but no complete sequences or pairs
 			const tehai: Hai[] = [
 				manzu(1),
 				manzu(2),
@@ -260,13 +260,12 @@ describe("calculateShanten", () => {
 			];
 
 			const result = calculateShanten(tehai);
-			// This is 4-shanten (has some partial sequences)
-			expect(result.shanten).toBeGreaterThanOrEqual(3);
+			expect(result.shanten).toBe(4);
 		});
 	});
 
 	describe("14 tiles - Shanten calculation", () => {
-		it("should calculate shanten for non-winning 14 tile hand", () => {
+		it("should calculate 1-shanten for non-winning 14 tile hand", () => {
 			const tehai: Hai[] = [
 				manzu(1),
 				manzu(1),
@@ -286,7 +285,7 @@ describe("calculateShanten", () => {
 
 			const result = calculateShanten(tehai);
 			expect(result.isAgari).toBe(false);
-			expect(result.shanten).toBeGreaterThanOrEqual(0);
+			expect(result.shanten).toBe(1);
 		});
 
 		it("should return shanten 0 for 14 tiles one discard from tenpai", () => {
@@ -496,17 +495,15 @@ describe("calculateShanten", () => {
 			];
 
 			const result = calculateShanten(tehai);
-			// Should be able to use 3 as koutsu and 1 as part of another combination
-			// or use as koutsu + 1 extra tile
-			expect(result.shanten).toBeGreaterThanOrEqual(-1);
-			expect(result.shanten).toBeLessThanOrEqual(1);
+			// Can form 3 syuntsu + 1 koutsu + janto candidate = tenpai
+			expect(result.shanten).toBe(0);
 		});
 
 		it("should handle empty hand gracefully", () => {
 			const tehai: Hai[] = [];
 			const result = calculateShanten(tehai);
-			// Empty hand should have high shanten
-			expect(result.shanten).toBeGreaterThan(0);
+			// Empty hand has maximum shanten
+			expect(result.shanten).toBe(8);
 		});
 
 		it("should reject hands with more than 4 of the same tile", () => {
@@ -551,8 +548,7 @@ describe("calculateShanten", () => {
 			];
 
 			const result = calculateShanten(tehai);
-			expect(result.shanten).toBeGreaterThanOrEqual(-1);
-			expect(result.shanten).toBeLessThanOrEqual(8);
+			expect(result.shanten).toBe(0);
 		});
 		it("should handle closed waits correctly", () => {
 			// Penchan wait (edge wait)
@@ -623,7 +619,7 @@ describe("calculateShanten", () => {
 	});
 
 	describe("Known standard shanten values", () => {
-		it("should return correct shanten for 1-2-3-4-5-6-7-8-9 pattern", () => {
+		it("should return 1-shanten for 1-2-3-4-5-6-7-8-9 pattern", () => {
 			// Nine Gates wait pattern (13 tiles)
 			const tehai: Hai[] = [
 				manzu(1),
@@ -642,8 +638,7 @@ describe("calculateShanten", () => {
 			];
 
 			const result = calculateShanten(tehai);
-			// This is actually 1-shanten since we have extra tile breaking the pattern
-			expect(result.shanten).toBeGreaterThanOrEqual(0);
+			expect(result.shanten).toBe(1);
 		});
 
 		it("should handle repeated sequences correctly", () => {

--- a/app/lib/hai/shanten.ts
+++ b/app/lib/hai/shanten.ts
@@ -13,10 +13,19 @@ interface ShantenResult {
  * Returns the minimum shanten number considering:
  * - Standard form (4 mentsu + 1 janto)
  * - Seven pairs (chiitoitsu)
+ *
+ * Note:
+ * - Agari (win) check: based on 14 tiles
+ * - Shanten calculation: based on 13 tiles (if 14 tiles provided, tries all possible discards)
  */
 export function calculateShanten(tehai: Hai[]): ShantenResult {
+	// Validate tile counts (no more than 4 of the same tile)
+	if (!validateTehai(tehai)) {
+		throw new Error("Invalid hand: a tile appears more than 4 times");
+	}
+
 	if (tehai.length === 14) {
-		// Check if already winning
+		// Check if already winning (agari check is based on 14 tiles)
 		const tehaiIndex: TehaiIndex = Array(34).fill(0);
 		for (const hai of tehai) {
 			tehaiIndex[haiToIndex(hai) - 1] += 1;
@@ -24,8 +33,28 @@ export function calculateShanten(tehai: Hai[]): ShantenResult {
 		if (checkAgari(tehaiIndex)) {
 			return { shanten: -1, isTenpai: false, isAgari: true };
 		}
+
+		// For 14 tiles, try removing each tile and calculate shanten for the remaining 13
+		// Return the minimum shanten (best case after discard)
+		let minShanten = 13; // Maximum possible
+		for (let i = 0; i < 14; i++) {
+			const tehai13 = tehai.filter((_, idx) => idx !== i);
+			const standardShanten = calcStandardShanten(tehai13);
+			const chiitoiShanten = calcChiitoiShanten(tehai13);
+			const shanten = Math.min(standardShanten, chiitoiShanten);
+			if (shanten < minShanten) {
+				minShanten = shanten;
+			}
+		}
+
+		return {
+			shanten: minShanten,
+			isTenpai: minShanten === 0,
+			isAgari: false,
+		};
 	}
 
+	// For 13 tiles, calculate shanten normally
 	const standardShanten = calcStandardShanten(tehai);
 	const chiitoiShanten = calcChiitoiShanten(tehai);
 
@@ -36,6 +65,21 @@ export function calculateShanten(tehai: Hai[]): ShantenResult {
 		isTenpai: minShanten === 0,
 		isAgari: false,
 	};
+}
+
+/**
+ * Validate that no tile appears more than 4 times
+ */
+function validateTehai(tehai: Hai[]): boolean {
+	const count: Record<string, number> = {};
+	for (const hai of tehai) {
+		const key = `${hai.kind}_${hai.value}`;
+		count[key] = (count[key] || 0) + 1;
+		if (count[key] > 4) {
+			return false;
+		}
+	}
+	return true;
 }
 
 function checkAgari(tehaiIndex: TehaiIndex): boolean {
@@ -216,11 +260,12 @@ function calcShantenForTehai(tehaiIndex: TehaiIndex): number {
 /**
  * Calculate shanten for seven pairs (chiitoitsu)
  * shanten = 6 - (number of pairs)
- * Special case: if 6 pairs + 1 tile, shanten = 0 (tenpai)
+ * With 7 pairs, shanten = -1 (complete)
+ * Note: This function expects exactly 13 tiles
  */
 function calcChiitoiShanten(tehai: Hai[]): number {
-	if (tehai.length !== 13 && tehai.length !== 14) {
-		return 8; // Invalid
+	if (tehai.length !== 13) {
+		return 8; // Invalid - should only receive 13 tiles
 	}
 
 	const pairCount = countPairs(tehai);

--- a/app/lib/hai/shanten.ts
+++ b/app/lib/hai/shanten.ts
@@ -119,9 +119,8 @@ function checkAgari(tehaiIndex: TehaiIndex): boolean {
 	}
 
 	// Chiitoitsu check
-	if (new Set(jantoCandidates).size === 7) {
-		return true;
-	}
+	const pairKindCount = tehaiIndex.filter((count) => count >= 2).length;
+	if (pairKindCount === 7) return true;
 
 	return false;
 }

--- a/app/routes/play.tsx
+++ b/app/routes/play.tsx
@@ -136,7 +136,9 @@ export default function Page({ loaderData }: Route.ComponentProps) {
 
 			<div className="max-w-6xl mx-auto">
 				<div className="mb-2 md:mb-3">
-					<h1 className="text-xl md:text-2xl font-bold text-yellow-400">対局中</h1>
+					<h1 className="text-xl md:text-2xl font-bold text-yellow-400">
+						対局中
+					</h1>
 				</div>
 				<div className="grid grid-cols-1 md:grid-cols-2 gap-1 md:gap-2 mb-2 md:mb-3 text-sm md:text-base bg-[#0F2918] rounded-lg p-2 md:p-3 border border-[#1A472A]">
 					<p>
@@ -169,7 +171,10 @@ export default function Page({ loaderData }: Route.ComponentProps) {
 						{indexedTehai.map((hai) => (
 							<Form key={hai.index} method="post" action="/api/tedashi">
 								<input type="hidden" name="index" value={hai.index} />
-								<button type="submit" aria-label={`捨てる ${hai.kind} ${hai.value}`}>
+								<button
+									type="submit"
+									aria-label={`捨てる ${hai.kind} ${hai.value}`}
+								>
 									<img
 										src={`/hai/${hai.kind}_${hai.value}.png`}
 										alt={`${hai.kind} ${hai.value}`}
@@ -201,7 +206,10 @@ export default function Page({ loaderData }: Route.ComponentProps) {
 							{firstRowTehai.map((hai) => (
 								<Form key={hai.index} method="post" action="/api/tedashi">
 									<input type="hidden" name="index" value={hai.index} />
-									<button type="submit" aria-label={`捨てる ${hai.kind} ${hai.value}`}>
+									<button
+										type="submit"
+										aria-label={`捨てる ${hai.kind} ${hai.value}`}
+									>
 										<img
 											src={`/hai/${hai.kind}_${hai.value}.png`}
 											alt={`${hai.kind} ${hai.value}`}
@@ -216,7 +224,10 @@ export default function Page({ loaderData }: Route.ComponentProps) {
 							{secondRowTehai.map((hai) => (
 								<Form key={hai.index} method="post" action="/api/tedashi">
 									<input type="hidden" name="index" value={hai.index} />
-									<button type="submit" aria-label={`捨てる ${hai.kind} ${hai.value}`}>
+									<button
+										type="submit"
+										aria-label={`捨てる ${hai.kind} ${hai.value}`}
+									>
 										<img
 											src={`/hai/${hai.kind}_${hai.value}.png`}
 											alt={`${hai.kind} ${hai.value}`}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	plugins: [tsconfigPaths()],
+	test: {
+		globals: true,
+	},
+});


### PR DESCRIPTION
## Summary

Fix the shanten calculation logic to properly handle 13 vs 14 tile hands and add comprehensive test coverage.

## Changes

### Fixed Shanten Calculation
- **Shanten calculation is now based on 13 tiles** (correct mahjong rules)
- For 14-tile hands, the function now tries all possible discards (14 combinations) and returns the minimum shanten
- **Agari (win) check remains based on 14 tiles** (as it should be)

### Added Validation
- Throws error if any tile appears more than 4 times (invalid hand)
- Prevents impossible hands from being processed

### Test Coverage
- Added comprehensive vitest test suite with **29 tests** covering:
  - 14-tile winning hands (agari)
  - 13-tile tenpai (ready hands)
  - Various shanten levels (0, 1, 2+)
  - 13 vs 14 tile distinction
  - Edge cases (honor tiles, 4 identical tiles, validation)
  - Wait types (penchan, kanchan, shaanpon)
  - Chiitoitsu vs standard form selection

### Files Changed
- `app/lib/hai/shanten.ts` - Fixed calculation logic and added validation
- `app/lib/hai/shanten.test.ts` - New comprehensive test suite
- `vitest.config.ts` - New vitest configuration