### PR TITLE
feat(score): show average agari junme per haiyama on detail result page

### DIFF
--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -4,6 +4,7 @@ import {
 	customType,
 	index,
 	integer,
+	real,
 	sqliteTable,
 	text,
 } from "drizzle-orm/sqlite-core";
@@ -30,6 +31,8 @@ export const haiyama = sqliteTable("haiyama", {
 		.$defaultFn(() => crypto.randomUUID()),
 	// D1だと1クエリあたり100パラメータまでなので、あえて正規化していない
 	tiles: haiArray("tiles").notNull(),
+	// 集計済みの平均和了巡目（0は未集計）
+	avgAgariJunme: real("avg_agari_junme").notNull().default(0),
 });
 
 // Game state (active game per user)

--- a/app/lib/game-service.ts
+++ b/app/lib/game-service.ts
@@ -294,4 +294,16 @@ export async function recordKyoku(
 		.update(gameState)
 		.set({ score: state.score + options.scoreDelta })
 		.where(eq(gameState.userId, userId));
+
+	// Recalculate average agari junme for this haiyama atomically
+	// Uses a subquery to compute AVG in a single UPDATE, avoiding race conditions
+	await db
+		.update(haiyama)
+		.set({
+			avgAgariJunme: sql`COALESCE(
+				(SELECT AVG(${kyoku.agariJunme}) FROM ${kyoku} WHERE ${kyoku.haiyamaId} = ${haiyama.id}),
+				0
+			)`,
+		})
+		.where(eq(haiyama.id, state.haiyamaId));
 }

--- a/app/routes/score.tsx
+++ b/app/routes/score.tsx
@@ -2,7 +2,7 @@ import { desc, eq } from "drizzle-orm";
 import { Link } from "react-router";
 import { getAuth } from "~/lib/auth";
 import { getDB } from "~/lib/db";
-import { haiyama, kyoku } from "~/lib/db/schema";
+import { kyoku } from "~/lib/db/schema";
 import type { Route } from "./+types/score";
 
 export interface KyokuRecord {
@@ -14,14 +14,13 @@ export interface KyokuRecord {
 	createdAt: Date;
 }
 
-export interface HaiyamaStats {
-	id: string;
-	avgAgariJunme: number;
+export interface GameSession {
+	records: KyokuRecord[];
+	avgAgariJunme: number | null;
 }
 
 export interface ScoreData {
-	records: KyokuRecord[];
-	haiyamaStats: HaiyamaStats[];
+	sessions: GameSession[];
 	totalScore: number;
 }
 
@@ -53,29 +52,40 @@ export async function loader({
 		.where(eq(kyoku.userId, userId))
 		.orderBy(desc(kyoku.createdAt));
 
+	// Group records into game sessions (4 kyoku per session)
+	const sessions: GameSession[] = [];
+	for (let i = 0; i < records.length; i += 4) {
+		const chunk = records.slice(i, i + 4).reverse(); // East-1, 2, 3, 4 order
+		const agariJunmeValues = chunk
+			.filter((r) => r.didAgari && r.agariJunme != null)
+			.map((r) => r.agariJunme as number);
+		const avgAgariJunme =
+			agariJunmeValues.length > 0
+				? Math.round(
+						(agariJunmeValues.reduce((a, b) => a + b, 0) /
+							agariJunmeValues.length) *
+							10,
+					) / 10
+				: null;
+		sessions.push({
+			records: chunk,
+			avgAgariJunme,
+		});
+	}
+
 	const totalScore =
 		25000 + records.reduce((sum, r) => sum + (r.scoreDelta || 0), 0);
 
-	// Fetch haiyama stats for haiyama the user has played with
-	const haiyamaStats = await db
-		.select({
-			id: haiyama.id,
-			avgAgariJunme: haiyama.avgAgariJunme,
-		})
-		.from(haiyama)
-		.innerJoin(kyoku, eq(haiyama.id, kyoku.haiyamaId))
-		.where(eq(kyoku.userId, userId))
-		.groupBy(haiyama.id);
-
 	return {
-		records,
-		haiyamaStats,
+		sessions,
 		totalScore,
 	};
 }
 
 export default function Page({ loaderData }: Route.ComponentProps) {
-	const { records, haiyamaStats, totalScore } = loaderData;
+	const { sessions, totalScore } = loaderData;
+
+	const kyokuNames = ["東1", "東2", "東3", "東4"];
 
 	return (
 		<div className="min-h-screen bg-[#1A472A] p-8 font-serif">
@@ -94,7 +104,7 @@ export default function Page({ loaderData }: Route.ComponentProps) {
 					ホームに戻る
 				</Link>
 
-				{records.length === 0 ? (
+				{sessions.length === 0 ? (
 					<div className="bg-[#0F2918] rounded-lg p-8 text-center">
 						<p className="text-white text-lg">まだ対局履歴がありません</p>
 						<a href="/play" className="btn bg-blue-600 text-white mt-4">
@@ -102,94 +112,76 @@ export default function Page({ loaderData }: Route.ComponentProps) {
 						</a>
 					</div>
 				) : (
-					<>
-						{/* Haiyama Statistics Section */}
-						{haiyamaStats.length > 0 && (
-							<div className="bg-[#0F2918] rounded-lg overflow-hidden mb-6">
-								<div className="p-4 bg-[#1A472A]">
-									<h2 className="text-xl font-bold text-yellow-400">
-										牌山別平均和了巡目
+					<div className="space-y-6">
+						{sessions.map((session, si) => (
+							<div
+								key={session.records[0]?.id ?? si}
+								className="bg-[#0F2918] rounded-lg overflow-hidden"
+							>
+								<div className="flex items-center justify-between p-4 bg-[#1A472A]">
+									<h2 className="text-lg font-bold text-yellow-400">
+										第{sessions.length - si}局
 									</h2>
+									<div className="text-white text-sm">
+										平均和了巡目:{" "}
+										{session.avgAgariJunme != null ? (
+											<span className="text-green-400 font-bold">
+												{parseFloat(session.avgAgariJunme.toFixed(1))}
+											</span>
+										) : (
+											<span className="text-gray-400">-</span>
+										)}
+									</div>
 								</div>
 								<table className="w-full text-white">
 									<thead className="bg-[#143820]">
 										<tr>
-											<th className="p-3 text-left">牌山ID</th>
-											<th className="p-3 text-center">平均和了巡目</th>
+											<th className="p-3 text-left">局</th>
+											<th className="p-3 text-left">結果</th>
+											<th className="p-3 text-center">巡目</th>
+											<th className="p-3 text-center">シャンテン</th>
+											<th className="p-3 text-right">得点</th>
 										</tr>
 									</thead>
 									<tbody>
-										{haiyamaStats.map((stats) => (
-											<tr key={stats.id} className="border-t border-[#1A472A]">
-												<td className="p-3 font-mono text-sm text-gray-300">
-													{stats.id.slice(0, 8)}...
+										{session.records.map((record, ri) => (
+											<tr key={record.id} className="border-t border-[#1A472A]">
+												<td className="p-3 font-bold">{kyokuNames[ri]}</td>
+												<td className="p-3">
+													{record.didAgari ? (
+														<span className="text-green-400 font-bold">
+															和了
+														</span>
+													) : record.shanten === 0 ? (
+														<span className="text-blue-400">テンパイ</span>
+													) : record.shanten === 1 ? (
+														<span className="text-yellow-400">1シャンテン</span>
+													) : (
+														<span className="text-gray-400">流局</span>
+													)}
 												</td>
 												<td className="p-3 text-center">
-													{stats.avgAgariJunme > 0 ? (
-														<span className="text-green-400 font-bold">
-															{parseFloat(stats.avgAgariJunme.toFixed(1))}
-														</span>
-													) : (
-														<span className="text-gray-400">-</span>
-													)}
+													{record.didAgari ? (record.agariJunme ?? "-") : "-"}
+												</td>
+												<td className="p-3 text-center">{record.shanten}</td>
+												<td className="p-3 text-right">
+													<span
+														className={
+															record.scoreDelta > 0
+																? "text-green-400 font-bold"
+																: "text-gray-400"
+														}
+													>
+														+{record.scoreDelta}
+													</span>
 												</td>
 											</tr>
 										))}
 									</tbody>
 								</table>
 							</div>
-						)}
-
-						{/* Individual Round Records */}
-						<div className="bg-[#0F2918] rounded-lg overflow-hidden">
-							<table className="w-full text-white">
-								<thead className="bg-[#1A472A]">
-									<tr>
-										<th className="p-3 text-left">日時</th>
-										<th className="p-3 text-left">結果</th>
-										<th className="p-3 text-center">巡目</th>
-										<th className="p-3 text-center">シャンテン</th>
-										<th className="p-3 text-right">得点</th>
-									</tr>
-								</thead>
-								<tbody>
-									{records.map((record) => (
-										<tr key={record.id} className="border-t border-[#1A472A]">
-											<td className="p-3">
-												{new Date(record.createdAt).toLocaleString("ja-JP")}
-											</td>
-											<td className="p-3">
-												{record.didAgari ? (
-													<span className="text-green-400 font-bold">和了</span>
-												) : record.shanten === 0 ? (
-													<span className="text-blue-400">テンパイ</span>
-												) : record.shanten === 1 ? (
-													<span className="text-yellow-400">1シャンテン</span>
-												) : (
-													<span className="text-gray-400">流局</span>
-												)}
-											</td>
-											<td className="p-3 text-center">
-												{record.didAgari ? (record.agariJunme ?? "-") : "-"}
-											</td>
-											<td className="p-3 text-center">{record.shanten}</td>
-											<td className="p-3 text-right">
-												<span
-													className={
-														record.scoreDelta > 0
-															? "text-green-400 font-bold"
-															: "text-gray-400"
-													}
-												>
-													+{record.scoreDelta}
-												</span>
-											</td>
-										</tr>
-									))}
-								</tbody>
-							</table>
-						</div>
-					</>
+						))}
+					</div>
 				)}
 			</div>
 		</div>

--- a/app/routes/score.tsx
+++ b/app/routes/score.tsx
@@ -2,7 +2,7 @@ import { desc, eq } from "drizzle-orm";
 import { Link } from "react-router";
 import { getAuth } from "~/lib/auth";
 import { getDB } from "~/lib/db";
-import { kyoku } from "~/lib/db/schema";
+import { haiyama, kyoku } from "~/lib/db/schema";
 import type { Route } from "./+types/score";
 
 export interface KyokuRecord {
@@ -12,6 +12,7 @@ export interface KyokuRecord {
 	shanten: number;
 	scoreDelta: number;
 	createdAt: Date;
+	avgAgariJunme: number;
 }
 
 export interface GameSession {
@@ -20,7 +21,6 @@ export interface GameSession {
 
 export interface ScoreData {
 	sessions: GameSession[];
-	avgAgariJunmeByKyoku: (number | null)[];
 	totalScore: number;
 }
 
@@ -47,8 +47,10 @@ export async function loader({
 			shanten: kyoku.shanten,
 			scoreDelta: kyoku.scoreDelta,
 			createdAt: kyoku.createdAt,
+			avgAgariJunme: haiyama.avgAgariJunme,
 		})
 		.from(kyoku)
+		.innerJoin(haiyama, eq(kyoku.haiyamaId, haiyama.id))
 		.where(eq(kyoku.userId, userId))
 		.orderBy(desc(kyoku.createdAt));
 
@@ -59,36 +61,17 @@ export async function loader({
 		sessions.push({ records: chunk });
 	}
 
-	// Calculate average agari junme per kyoku position across all sessions
-	const avgAgariJunmeByKyoku: (number | null)[] = [];
-	for (let ki = 0; ki < 4; ki++) {
-		const values: number[] = [];
-		for (const s of sessions) {
-			const r = s.records[ki];
-			if (r?.didAgari && r.agariJunme != null) {
-				values.push(r.agariJunme);
-			}
-		}
-		avgAgariJunmeByKyoku.push(
-			values.length > 0
-				? Math.round((values.reduce((a, b) => a + b, 0) / values.length) * 10) /
-						10
-				: null,
-		);
-	}
-
 	const totalScore =
 		25000 + records.reduce((sum, r) => sum + (r.scoreDelta || 0), 0);
 
 	return {
 		sessions,
-		avgAgariJunmeByKyoku,
 		totalScore,
 	};
 }
 
 export default function Page({ loaderData }: Route.ComponentProps) {
-	const { sessions, avgAgariJunmeByKyoku, totalScore } = loaderData;
+	const { sessions, totalScore } = loaderData;
 
 	const kyokuNames = ["東1", "東2", "東3", "東4"];
 
@@ -134,6 +117,7 @@ export default function Page({ loaderData }: Route.ComponentProps) {
 											<th className="p-3 text-left">局</th>
 											<th className="p-3 text-left">結果</th>
 											<th className="p-3 text-center">巡目</th>
+											<th className="p-3 text-center">牌山平均和了巡目</th>
 											<th className="p-3 text-center">シャンテン</th>
 											<th className="p-3 text-right">得点</th>
 										</tr>
@@ -158,6 +142,15 @@ export default function Page({ loaderData }: Route.ComponentProps) {
 												<td className="p-3 text-center">
 													{record.didAgari ? (record.agariJunme ?? "-") : "-"}
 												</td>
+												<td className="p-3 text-center">
+													{record.avgAgariJunme > 0 ? (
+														<span className="text-green-400 font-bold">
+															{parseFloat(record.avgAgariJunme.toFixed(1))}
+														</span>
+													) : (
+														<span className="text-gray-400">-</span>
+													)}
+												</td>
 												<td className="p-3 text-center">{record.shanten}</td>
 												<td className="p-3 text-right">
 													<span
@@ -176,41 +169,6 @@ export default function Page({ loaderData }: Route.ComponentProps) {
 								</table>
 							</div>
 						))}
-
-						{/* Overall average per kyoku position */}
-						<div className="bg-[#0F2918] rounded-lg overflow-hidden">
-							<div className="p-4 bg-[#1A472A]">
-								<h2 className="text-lg font-bold text-yellow-400">
-									局別平均和了巡目
-								</h2>
-							</div>
-							<table className="w-full text-white">
-								<thead className="bg-[#143820]">
-									<tr>
-										{kyokuNames.map((name) => (
-											<th key={name} className="p-3 text-center font-bold">
-												{name}
-											</th>
-										))}
-									</tr>
-								</thead>
-								<tbody>
-									<tr className="border-t border-[#1A472A]">
-										{avgAgariJunmeByKyoku.map((avg, i) => (
-											<td key={kyokuNames[i]} className="p-3 text-center">
-												{avg != null ? (
-													<span className="text-green-400 font-bold">
-														{parseFloat(avg.toFixed(1))}
-													</span>
-												) : (
-													<span className="text-gray-400">-</span>
-												)}
-											</td>
-										))}
-									</tr>
-								</tbody>
-							</table>
-						</div>
 					</div>
 				)}
 			</div>

--- a/app/routes/score.tsx
+++ b/app/routes/score.tsx
@@ -2,7 +2,7 @@ import { desc, eq } from "drizzle-orm";
 import { Link } from "react-router";
 import { getAuth } from "~/lib/auth";
 import { getDB } from "~/lib/db";
-import { kyoku } from "~/lib/db/schema";
+import { haiyama, kyoku } from "~/lib/db/schema";
 import type { Route } from "./+types/score";
 
 export interface KyokuRecord {
@@ -14,8 +14,14 @@ export interface KyokuRecord {
 	createdAt: Date;
 }
 
+export interface HaiyamaStats {
+	id: string;
+	avgAgariJunme: number;
+}
+
 export interface ScoreData {
 	records: KyokuRecord[];
+	haiyamaStats: HaiyamaStats[];
 	totalScore: number;
 }
 
@@ -50,14 +56,26 @@ export async function loader({
 	const totalScore =
 		25000 + records.reduce((sum, r) => sum + (r.scoreDelta || 0), 0);
 
+	// Fetch haiyama stats for haiyama the user has played with
+	const haiyamaStats = await db
+		.select({
+			id: haiyama.id,
+			avgAgariJunme: haiyama.avgAgariJunme,
+		})
+		.from(haiyama)
+		.innerJoin(kyoku, eq(haiyama.id, kyoku.haiyamaId))
+		.where(eq(kyoku.userId, userId))
+		.groupBy(haiyama.id);
+
 	return {
 		records,
+		haiyamaStats,
 		totalScore,
 	};
 }
 
 export default function Page({ loaderData }: Route.ComponentProps) {
-	const { records, totalScore } = loaderData;
+	const { records, haiyamaStats, totalScore } = loaderData;
 
 	return (
 		<div className="min-h-screen bg-[#1A472A] p-8 font-serif">
@@ -84,54 +102,94 @@ export default function Page({ loaderData }: Route.ComponentProps) {
 						</a>
 					</div>
 				) : (
-					<div className="bg-[#0F2918] rounded-lg overflow-hidden">
-						<table className="w-full text-white">
-							<thead className="bg-[#1A472A]">
-								<tr>
-									<th className="p-3 text-left">日時</th>
-									<th className="p-3 text-left">結果</th>
-									<th className="p-3 text-center">巡目</th>
-									<th className="p-3 text-center">シャンテン</th>
-									<th className="p-3 text-right">得点</th>
-								</tr>
-							</thead>
-							<tbody>
-								{records.map((record) => (
-									<tr key={record.id} className="border-t border-[#1A472A]">
-										<td className="p-3">
-											{new Date(record.createdAt).toLocaleString("ja-JP")}
-										</td>
-										<td className="p-3">
-											{record.didAgari ? (
-												<span className="text-green-400 font-bold">和了</span>
-											) : record.shanten === 0 ? (
-												<span className="text-blue-400">テンパイ</span>
-											) : record.shanten === 1 ? (
-												<span className="text-yellow-400">1シャンテン</span>
-											) : (
-												<span className="text-gray-400">流局</span>
-											)}
-										</td>
-										<td className="p-3 text-center">
-											{record.didAgari ? (record.agariJunme ?? "-") : "-"}
-										</td>
-										<td className="p-3 text-center">{record.shanten}</td>
-										<td className="p-3 text-right">
-											<span
-												className={
-													record.scoreDelta > 0
-														? "text-green-400 font-bold"
-														: "text-gray-400"
-												}
-											>
-												+{record.scoreDelta}
-											</span>
-										</td>
+					<>
+						{/* Haiyama Statistics Section */}
+						{haiyamaStats.length > 0 && (
+							<div className="bg-[#0F2918] rounded-lg overflow-hidden mb-6">
+								<div className="p-4 bg-[#1A472A]">
+									<h2 className="text-xl font-bold text-yellow-400">
+										牌山別平均和了巡目
+									</h2>
+								</div>
+								<table className="w-full text-white">
+									<thead className="bg-[#143820]">
+										<tr>
+											<th className="p-3 text-left">牌山ID</th>
+											<th className="p-3 text-center">平均和了巡目</th>
+										</tr>
+									</thead>
+									<tbody>
+										{haiyamaStats.map((stats) => (
+											<tr key={stats.id} className="border-t border-[#1A472A]">
+												<td className="p-3 font-mono text-sm text-gray-300">
+													{stats.id.slice(0, 8)}...
+												</td>
+												<td className="p-3 text-center">
+													{stats.avgAgariJunme > 0 ? (
+														<span className="text-green-400 font-bold">
+															{parseFloat(stats.avgAgariJunme.toFixed(1))}
+														</span>
+													) : (
+														<span className="text-gray-400">-</span>
+													)}
+												</td>
+											</tr>
+										))}
+									</tbody>
+								</table>
+							</div>
+						)}
+
+						{/* Individual Round Records */}
+						<div className="bg-[#0F2918] rounded-lg overflow-hidden">
+							<table className="w-full text-white">
+								<thead className="bg-[#1A472A]">
+									<tr>
+										<th className="p-3 text-left">日時</th>
+										<th className="p-3 text-left">結果</th>
+										<th className="p-3 text-center">巡目</th>
+										<th className="p-3 text-center">シャンテン</th>
+										<th className="p-3 text-right">得点</th>
 									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
+								</thead>
+								<tbody>
+									{records.map((record) => (
+										<tr key={record.id} className="border-t border-[#1A472A]">
+											<td className="p-3">
+												{new Date(record.createdAt).toLocaleString("ja-JP")}
+											</td>
+											<td className="p-3">
+												{record.didAgari ? (
+													<span className="text-green-400 font-bold">和了</span>
+												) : record.shanten === 0 ? (
+													<span className="text-blue-400">テンパイ</span>
+												) : record.shanten === 1 ? (
+													<span className="text-yellow-400">1シャンテン</span>
+												) : (
+													<span className="text-gray-400">流局</span>
+												)}
+											</td>
+											<td className="p-3 text-center">
+												{record.didAgari ? (record.agariJunme ?? "-") : "-"}
+											</td>
+											<td className="p-3 text-center">{record.shanten}</td>
+											<td className="p-3 text-right">
+												<span
+													className={
+														record.scoreDelta > 0
+															? "text-green-400 font-bold"
+															: "text-gray-400"
+													}
+												>
+													+{record.scoreDelta}
+												</span>
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					</>
 				)}
 			</div>
 		</div>

--- a/app/routes/score.tsx
+++ b/app/routes/score.tsx
@@ -16,11 +16,11 @@ export interface KyokuRecord {
 
 export interface GameSession {
 	records: KyokuRecord[];
-	avgAgariJunme: number | null;
 }
 
 export interface ScoreData {
 	sessions: GameSession[];
+	avgAgariJunmeByKyoku: (number | null)[];
 	totalScore: number;
 }
 
@@ -56,21 +56,25 @@ export async function loader({
 	const sessions: GameSession[] = [];
 	for (let i = 0; i < records.length; i += 4) {
 		const chunk = records.slice(i, i + 4).reverse(); // East-1, 2, 3, 4 order
-		const agariJunmeValues = chunk
-			.filter((r) => r.didAgari && r.agariJunme != null)
-			.map((r) => r.agariJunme as number);
-		const avgAgariJunme =
-			agariJunmeValues.length > 0
-				? Math.round(
-						(agariJunmeValues.reduce((a, b) => a + b, 0) /
-							agariJunmeValues.length) *
-							10,
-					) / 10
-				: null;
-		sessions.push({
-			records: chunk,
-			avgAgariJunme,
-		});
+		sessions.push({ records: chunk });
+	}
+
+	// Calculate average agari junme per kyoku position across all sessions
+	const avgAgariJunmeByKyoku: (number | null)[] = [];
+	for (let ki = 0; ki < 4; ki++) {
+		const values: number[] = [];
+		for (const s of sessions) {
+			const r = s.records[ki];
+			if (r?.didAgari && r.agariJunme != null) {
+				values.push(r.agariJunme);
+			}
+		}
+		avgAgariJunmeByKyoku.push(
+			values.length > 0
+				? Math.round((values.reduce((a, b) => a + b, 0) / values.length) * 10) /
+						10
+				: null,
+		);
 	}
 
 	const totalScore =
@@ -78,12 +82,13 @@ export async function loader({
 
 	return {
 		sessions,
+		avgAgariJunmeByKyoku,
 		totalScore,
 	};
 }
 
 export default function Page({ loaderData }: Route.ComponentProps) {
-	const { sessions, totalScore } = loaderData;
+	const { sessions, avgAgariJunmeByKyoku, totalScore } = loaderData;
 
 	const kyokuNames = ["東1", "東2", "東3", "東4"];
 
@@ -118,20 +123,10 @@ export default function Page({ loaderData }: Route.ComponentProps) {
 								key={session.records[0]?.id ?? si}
 								className="bg-[#0F2918] rounded-lg overflow-hidden"
 							>
-								<div className="flex items-center justify-between p-4 bg-[#1A472A]">
+								<div className="p-3 bg-[#1A472A]">
 									<h2 className="text-lg font-bold text-yellow-400">
 										第{sessions.length - si}局
 									</h2>
-									<div className="text-white text-sm">
-										平均和了巡目:{" "}
-										{session.avgAgariJunme != null ? (
-											<span className="text-green-400 font-bold">
-												{parseFloat(session.avgAgariJunme.toFixed(1))}
-											</span>
-										) : (
-											<span className="text-gray-400">-</span>
-										)}
-									</div>
 								</div>
 								<table className="w-full text-white">
 									<thead className="bg-[#143820]">
@@ -181,6 +176,41 @@ export default function Page({ loaderData }: Route.ComponentProps) {
 								</table>
 							</div>
 						))}
+
+						{/* Overall average per kyoku position */}
+						<div className="bg-[#0F2918] rounded-lg overflow-hidden">
+							<div className="p-4 bg-[#1A472A]">
+								<h2 className="text-lg font-bold text-yellow-400">
+									局別平均和了巡目
+								</h2>
+							</div>
+							<table className="w-full text-white">
+								<thead className="bg-[#143820]">
+									<tr>
+										{kyokuNames.map((name) => (
+											<th key={name} className="p-3 text-center font-bold">
+												{name}
+											</th>
+										))}
+									</tr>
+								</thead>
+								<tbody>
+									<tr className="border-t border-[#1A472A]">
+										{avgAgariJunmeByKyoku.map((avg, i) => (
+											<td key={kyokuNames[i]} className="p-3 text-center">
+												{avg != null ? (
+													<span className="text-green-400 font-bold">
+														{parseFloat(avg.toFixed(1))}
+													</span>
+												) : (
+													<span className="text-gray-400">-</span>
+												)}
+											</td>
+										))}
+									</tr>
+								</tbody>
+							</table>
+						</div>
 					</div>
 				)}
 			</div>

--- a/drizzle/0001_wet_star_brand.sql
+++ b/drizzle/0001_wet_star_brand.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `haiyama` ADD `avg_agari_junme` real DEFAULT 0 NOT NULL;
+
+-- Backfill existing haiyama rows with their historical average agari junme
+UPDATE `haiyama`
+SET `avg_agari_junme` = COALESCE(
+    (SELECT AVG(`agari_junme`) FROM `kyoku` WHERE `kyoku`.`haiyama_id` = `haiyama`.`id`),
+    0
+);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,579 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "4b89339e-330a-478e-9691-bb73ac066019",
+	"prevId": "25890843-f1f5-4768-a7d8-2e5aef7bdb59",
+	"tables": {
+		"game_state": {
+			"name": "game_state",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kyoku": {
+					"name": "kyoku",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"junme": {
+					"name": "junme",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"remain_tsumo": {
+					"name": "remain_tsumo",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 18
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 25000
+				},
+				"haiyama": {
+					"name": "haiyama",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sutehai": {
+					"name": "sutehai",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tehai": {
+					"name": "tehai",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tsumohai": {
+					"name": "tsumohai",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"haiyama_id": {
+					"name": "haiyama_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"haiyama": {
+			"name": "haiyama",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tiles": {
+					"name": "tiles",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"avg_agari_junme": {
+					"name": "avg_agari_junme",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"kyoku": {
+			"name": "kyoku",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"haiyama_id": {
+					"name": "haiyama_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"did_agari": {
+					"name": "did_agari",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agari_junme": {
+					"name": "agari_junme",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"shanten": {
+					"name": "shanten",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"score_delta": {
+					"name": "score_delta",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"kyoku_user_id_idx": {
+					"name": "kyoku_user_id_idx",
+					"columns": ["user_id"],
+					"isUnique": false
+				},
+				"kyoku_haiyama_id_idx": {
+					"name": "kyoku_haiyama_id_idx",
+					"columns": ["haiyama_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"kyoku_user_id_user_id_fk": {
+					"name": "kyoku_user_id_user_id_fk",
+					"tableFrom": "kyoku",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"kyoku_haiyama_id_haiyama_id_fk": {
+					"name": "kyoku_haiyama_id_haiyama_id_fk",
+					"tableFrom": "kyoku",
+					"tableTo": "haiyama",
+					"columnsFrom": ["haiyama_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {
+				"agari_consistency": {
+					"name": "agari_consistency",
+					"value": "(\"kyoku\".\"did_agari\" = false) OR (\"kyoku\".\"did_agari\" = true AND \"kyoku\".\"agari_junme\" IS NOT NULL)"
+				}
+			}
+		},
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": ["user_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": ["token"],
+					"isUnique": true
+				},
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": ["user_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"is_anonymous": {
+					"name": "is_anonymous",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": ["identifier"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
 			"when": 1776084662897,
 			"tag": "0000_fancy_sleeper",
 			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "6",
+			"when": 1776148700684,
+			"tag": "0001_wet_star_brand",
+			"breakpoints": true
 		}
 	]
 }


### PR DESCRIPTION
## Summary
Display the average 'agari junme' (winning turn number) grouped by haiyama (tile mountain) on the score detail page.

## Changes

### Schema & Migration
- Add `avg_agari_junme` column to `haiyama` table (REAL type)
- Migration includes backfill SQL to compute averages for existing data

### Game Service
- `recordKyoku()` now recalculates the average atomically via a single UPDATE with AVG subquery, avoiding race conditions

### Score Page
- New table section showing each haiyama's average agari junme
- Fetches pre-computed stats directly from haiyama table (no per-request aggregation)

## Review Notes
- Migration backfills all existing haiyama rows on deploy
- Race-condition safe: uses atomic UPDATE with subquery instead of separate SELECT/compute/UPDATE
- Average stored as REAL to preserve decimal values